### PR TITLE
Fix open export directory on all platforms

### DIFF
--- a/export_tools.py
+++ b/export_tools.py
@@ -1,5 +1,6 @@
 import bpy
 import os
+import sys
 import subprocess
 import math
 from . import utils
@@ -575,9 +576,9 @@ class OpenExportDir(bpy.types.Operator):
 		# Try open export dir in OS
 		if len(act.export_dir) > 0:
 			try:
-				os.startfile(act.export_dir)
-			except:
-				subprocess.Popen(['xdg-open', act.export_dir])
+				utils.open_directory(act.export_dir)
+			except Exception as e:
+				print(f"Failed to open export directory: {e}")
 		else:
 			utils.show_message_box('Export FBX\'s before',
 								   'Info')

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,8 @@ PopTools Utils
 
 import bpy
 import os
+import sys
+import subprocess
 import bmesh
 import re
 from datetime import datetime
@@ -28,6 +30,18 @@ def ensure_directory_exists(path):
         os.makedirs(path)
         return True
     return False
+
+def open_directory(path):
+    """在操作系统中打开目录"""
+    try:
+        if sys.platform.startswith('win'):
+            os.startfile(path)
+        elif sys.platform == 'darwin':
+            subprocess.Popen(['open', path])
+        else:
+            subprocess.Popen(['xdg-open', path])
+    except Exception as e:
+        print(f"Failed to open directory {path}: {e}")
 
 def get_safe_filename(filename):
     """获取安全的文件名（移除非法字符）"""


### PR DESCRIPTION
## Summary
- add cross-platform `open_directory` helper in utils
- use helper in export path opener so macOS and Linux work properly

## Testing
- `flake8 export_tools.py utils.py`
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68410c95363083318416eeb36956dc4b